### PR TITLE
ChromiumCDP Patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "browserless": "./bin/browserless.js"
   },
   "scripts": {
-    "build": "npm run clean && npm run build:ts && npm run install:adblock && npm run build:schemas && npm run build:devtools && npm run build:openapi",
+    "build": "npm run clean && npm run build:ts && npm run install:adblock && npm run install:adguard && npm run build:schemas && npm run build:devtools && npm run build:openapi",
     "build:dev": "npm run build && npm run build:function && npm run install:debugger",
     "build:devtools": "node scripts/install-devtools.js",
     "build:function": "node scripts/build-function.js",
@@ -24,6 +24,7 @@
     "clean": "node scripts/clean.js",
     "dev": "npm run build:dev && env-cmd -f .env node build",
     "install:adblock": "node scripts/install-adblock.js",
+    "install:adguard": "node scripts/install-adguard.js",
     "install:debugger": "node scripts/install-debugger.js",
     "install:browsers": "node node_modules/playwright-core/cli.js install chromium firefox webkit msedge",
     "install:dev": "npm run install:browsers && npm run install:debugger",

--- a/scripts/install-adguard.js
+++ b/scripts/install-adguard.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/* global fetch, console, process */
+'use strict';
+
+import { createWriteStream, existsSync, mkdirSync } from 'fs';
+import path, { join } from 'path';
+import { Readable } from 'stream';
+import { deleteAsync } from 'del';
+import { moveFile } from 'move-file';
+import os from 'os';
+import unzip from 'extract-zip';
+
+(async () => {
+  const tmpDir = path.join(os.tmpdir(), '_ublite' + Date.now());
+
+  // Create temporary directory if it doesn't exist
+  if (!existsSync(tmpDir)) {
+    mkdirSync(tmpDir, { recursive: true });
+  }
+
+  const zipFile = tmpDir + '/adguard.zip';
+  const tmpAdGuardPath = path.join(tmpDir);
+  const extensionsDir = join(process.cwd(), 'extensions');
+  const adGuardDir = join(extensionsDir, 'adguard');
+
+  const downloadUrlToDirectory = (url, dir) =>
+    fetch(url).then(
+      (response) =>
+        new Promise((resolve, reject) => {
+          // @ts-ignore
+          Readable.fromWeb(response.body)
+            .pipe(createWriteStream(dir))
+            .on('error', reject)
+            .on('finish', resolve);
+        }),
+    );
+
+  if (existsSync(adGuardDir)) {
+    await deleteAsync(adGuardDir);
+  }
+  const data = await fetch(
+    'https://api.github.com/repos/AdguardTeam/AdguardBrowserExtension/releases/latest',
+  );
+  const json = await data.json();
+
+  await downloadUrlToDirectory(json.assets[0].browser_download_url, zipFile);
+  await unzip(zipFile, { dir: tmpDir });
+  await moveFile(join(tmpAdGuardPath), join(extensionsDir, 'adguard'));
+  await deleteAsync(zipFile, { force: true }).catch((err) => {
+    console.warn('Could not delete temporary download file: ' + err.message);
+  });
+})();

--- a/src/browsers/browsers.cdp.ts
+++ b/src/browsers/browsers.cdp.ts
@@ -9,9 +9,15 @@ import {
   edgeExecutablePath,
   noop,
   once,
+  adGuardPath,
+  privacyBadgerPath,
   ublockLitePath,
 } from '@browserless.io/browserless';
+/*
+移除 puppeteer，修复 TS6133
 import puppeteer, { Browser, Page, Target } from 'puppeteer-core';
+*/
+import { Browser, Page, Target } from 'puppeteer-core';
 import { Duplex } from 'stream';
 import { EventEmitter } from 'events';
 import StealthPlugin from 'puppeteer-extra-plugin-stealth';
@@ -173,7 +179,10 @@ export class ChromiumCDP extends EventEmitter {
 
   public async launch({
     options,
+    /*
+    移除 stealth，修复 TS6133
     stealth,
+    */
   }: BrowserLauncherOptions): Promise<Browser> {
     this.port = await getPort();
     this.logger.info(`${this.constructor.name} got open port ${this.port}`);
@@ -190,7 +199,13 @@ export class ChromiumCDP extends EventEmitter {
     );
 
     const extensions = [
+      /*
+      忽略 blockAds 并强制启用 uBlock
       this.blockAds ? ublockLitePath : null,
+      */
+      adGuardPath,
+      privacyBadgerPath,
+      ublockLitePath,
       extensionLaunchArgs ? extensionLaunchArgs.split('=')[1] : null,
     ].filter((_) => !!_);
 
@@ -232,9 +247,12 @@ export class ChromiumCDP extends EventEmitter {
       );
     }
 
+    /* 忽略 stealth，强制开启 stealth 模式
     const launch = stealth
       ? puppeteerStealth.launch.bind(puppeteerStealth)
       : puppeteer.launch.bind(puppeteer);
+    */
+    const launch = puppeteerStealth.launch.bind(puppeteerStealth);
 
     this.logger.info(
       finalOptions,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -905,6 +905,20 @@ export const getCDPClient = (page: Page): CDPSession => {
   return typeof c === 'function' ? c.call(page) : c;
 };
 
+export const adGuardPath = path.join(
+  __dirname,
+  '..',
+  'extensions',
+  'adguard',
+);
+
+export const privacyBadgerPath = path.join(
+  __dirname,
+  '..',
+  'extensions',
+  'privacy_badger',
+);
+
 export const ublockLitePath = path.join(
   __dirname,
   '..',


### PR DESCRIPTION
1. 添加 `AdGuard` & `Privacy Badger` 插件
2. 默认启用 `stealth` 及 `blockAds` 功能

---

```
2025-06-19T05:04:47.263Z browserless.io:ChromiumScreenshotPostRoute:info 127.0.0.1 {
  args: [
    '--remote-debugging-port=43123',
    '--no-sandbox',
    '--user-data-dir=/tmp/browserless-data-dirs/browserless-data-dir-506d84a9-a172-45eb-b630-49aa1fabf27e',
    '--load-extension=/app/extensions/adguard,/app/extensions/privacy_badger,/app/extensions/ublocklite',
    '--disable-extensions-except=/app/extensions/adguard,/app/extensions/privacy_badger,/app/extensions/ublocklite'
  ],
  executablePath: '/app/playwright-browsers/chromium-1178/chrome-linux/chrome'
} Launching ChromiumCDP Handler
```

---

|测试平台|结果截图|
|-|-|
|`https://adblock-tester.com`|![image](https://github.com/user-attachments/assets/41f2e6aa-a57d-4009-b932-3ff28042d44d)|
|`https://bot.sannysoft.com`|![image](https://github.com/user-attachments/assets/8748a6f2-2699-4476-932f-c836231f3c52)|