### PR TITLE
ChromiumCDP Patch

### DIFF
--- a/src/browsers/browsers.cdp.ts
+++ b/src/browsers/browsers.cdp.ts
@@ -15,6 +15,9 @@ import {
 import puppeteer, { Browser, Page, Target } from 'puppeteer-core';
 import { Duplex } from 'stream';
 import { EventEmitter } from 'events';
+// 引入 adblocker 及 recaptcha 插件
+import AdblockPlugin from 'puppeteer-extra-plugin-adblocker';
+import RecaptchaPlugin from 'puppeteer-extra-plugin-recaptcha';
 import StealthPlugin from 'puppeteer-extra-plugin-stealth';
 import getPort from 'get-port';
 import httpProxy from 'http-proxy';
@@ -22,6 +25,19 @@ import path from 'path';
 import playwright from 'playwright-core';
 import puppeteerStealth from 'puppeteer-extra';
 
+// 启用 AdblockPlugin 插件，启用 blockTrackersAndAnnoyances 功能
+puppeteerStealth.use(AdblockPlugin({
+  blockTrackersAndAnnoyances: true,
+  useCache: true,
+}));
+// 启用 RecaptchaPlugin 插件
+puppeteerStealth.use(RecaptchaPlugin({
+  provider: {
+    id: '2captcha',
+    token: process.env.TWOCAPTCHA_API_KEY || '',
+  },
+  visualFeedback: true,
+}));
 puppeteerStealth.use(StealthPlugin());
 
 export class ChromiumCDP extends EventEmitter {

--- a/src/browsers/browsers.cdp.ts
+++ b/src/browsers/browsers.cdp.ts
@@ -9,9 +9,14 @@ import {
   edgeExecutablePath,
   noop,
   once,
+  privacyBadgerPath,
   ublockLitePath,
 } from '@browserless.io/browserless';
+/*
+移除 puppeteer，修复 TS6133
 import puppeteer, { Browser, Page, Target } from 'puppeteer-core';
+*/
+import { Browser, Page, Target } from 'puppeteer-core';
 import { Duplex } from 'stream';
 import { EventEmitter } from 'events';
 import StealthPlugin from 'puppeteer-extra-plugin-stealth';
@@ -173,7 +178,10 @@ export class ChromiumCDP extends EventEmitter {
 
   public async launch({
     options,
+    /*
+    移除 stealth，修复 TS6133
     stealth,
+    */
   }: BrowserLauncherOptions): Promise<Browser> {
     this.port = await getPort();
     this.logger.info(`${this.constructor.name} got open port ${this.port}`);
@@ -190,7 +198,12 @@ export class ChromiumCDP extends EventEmitter {
     );
 
     const extensions = [
+      /*
+      忽略 blockAds 并强制启用 uBlock
       this.blockAds ? ublockLitePath : null,
+      */
+      privacyBadgerPath,
+      ublockLitePath,
       extensionLaunchArgs ? extensionLaunchArgs.split('=')[1] : null,
     ].filter((_) => !!_);
 
@@ -232,9 +245,12 @@ export class ChromiumCDP extends EventEmitter {
       );
     }
 
+    /* 忽略 stealth，强制开启 stealth 模式
     const launch = stealth
       ? puppeteerStealth.launch.bind(puppeteerStealth)
       : puppeteer.launch.bind(puppeteer);
+    */
+    const launch = puppeteerStealth.launch.bind(puppeteerStealth);
 
     this.logger.info(
       finalOptions,

--- a/src/browsers/browsers.cdp.ts
+++ b/src/browsers/browsers.cdp.ts
@@ -15,9 +15,8 @@ import {
 import puppeteer, { Browser, Page, Target } from 'puppeteer-core';
 import { Duplex } from 'stream';
 import { EventEmitter } from 'events';
-// 引入 adblocker 及 recaptcha 插件
+// 引入 adblocker 插件
 import AdblockPlugin from 'puppeteer-extra-plugin-adblocker';
-import RecaptchaPlugin from 'puppeteer-extra-plugin-recaptcha';
 import StealthPlugin from 'puppeteer-extra-plugin-stealth';
 import getPort from 'get-port';
 import httpProxy from 'http-proxy';
@@ -25,19 +24,6 @@ import path from 'path';
 import playwright from 'playwright-core';
 import puppeteerStealth from 'puppeteer-extra';
 
-// 启用 AdblockPlugin 插件，启用 blockTrackersAndAnnoyances 功能
-puppeteerStealth.use(AdblockPlugin({
-  blockTrackersAndAnnoyances: true,
-  useCache: true,
-}));
-// 启用 RecaptchaPlugin 插件
-puppeteerStealth.use(RecaptchaPlugin({
-  provider: {
-    id: '2captcha',
-    token: process.env.TWOCAPTCHA_API_KEY || '',
-  },
-  visualFeedback: true,
-}));
 puppeteerStealth.use(StealthPlugin());
 
 export class ChromiumCDP extends EventEmitter {
@@ -194,6 +180,14 @@ export class ChromiumCDP extends EventEmitter {
   }: BrowserLauncherOptions): Promise<Browser> {
     this.port = await getPort();
     this.logger.info(`${this.constructor.name} got open port ${this.port}`);
+
+    // stealth 模式下，启用 AdblockPlugin 插件，启用 blockTrackersAndAnnoyances 功能
+    if (this.blockAds) {
+      puppeteerStealth.use(AdblockPlugin({
+        blockTrackersAndAnnoyances: true,
+        useCache: true,
+      }));      
+    }
 
     const extensionLaunchArgs = options.args?.find((a) =>
       a.startsWith('--load-extension'),

--- a/src/browsers/browsers.cdp.ts
+++ b/src/browsers/browsers.cdp.ts
@@ -12,11 +12,7 @@ import {
   privacyBadgerPath,
   ublockLitePath,
 } from '@browserless.io/browserless';
-/*
-移除 puppeteer，修复 TS6133
 import puppeteer, { Browser, Page, Target } from 'puppeteer-core';
-*/
-import { Browser, Page, Target } from 'puppeteer-core';
 import { Duplex } from 'stream';
 import { EventEmitter } from 'events';
 import StealthPlugin from 'puppeteer-extra-plugin-stealth';
@@ -178,10 +174,7 @@ export class ChromiumCDP extends EventEmitter {
 
   public async launch({
     options,
-    /*
-    移除 stealth，修复 TS6133
     stealth,
-    */
   }: BrowserLauncherOptions): Promise<Browser> {
     this.port = await getPort();
     this.logger.info(`${this.constructor.name} got open port ${this.port}`);
@@ -198,12 +191,9 @@ export class ChromiumCDP extends EventEmitter {
     );
 
     const extensions = [
-      /*
-      忽略 blockAds 并强制启用 uBlock
+      // 引入 Privacy Badger 插件
+      this.blockAds ? privacyBadgerPath : null,
       this.blockAds ? ublockLitePath : null,
-      */
-      privacyBadgerPath,
-      ublockLitePath,
       extensionLaunchArgs ? extensionLaunchArgs.split('=')[1] : null,
     ].filter((_) => !!_);
 
@@ -245,12 +235,9 @@ export class ChromiumCDP extends EventEmitter {
       );
     }
 
-    /* 忽略 stealth，强制开启 stealth 模式
     const launch = stealth
       ? puppeteerStealth.launch.bind(puppeteerStealth)
       : puppeteer.launch.bind(puppeteer);
-    */
-    const launch = puppeteerStealth.launch.bind(puppeteerStealth);
 
     this.logger.info(
       finalOptions,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -905,6 +905,13 @@ export const getCDPClient = (page: Page): CDPSession => {
   return typeof c === 'function' ? c.call(page) : c;
 };
 
+export const privacyBadgerPath = path.join(
+  __dirname,
+  '..',
+  'extensions',
+  'privacy_badger',
+);
+
 export const ublockLitePath = path.join(
   __dirname,
   '..',


### PR DESCRIPTION
1. 添加 `ClearURLs` `Privacy Badger` 插件
2. 添加 `puppeteer-extra-plugin-adblocker` 插件

---

```
2025-06-19T05:04:47.263Z browserless.io:ChromiumScreenshotPostRoute:info 127.0.0.1 {
  args: [
    '--remote-debugging-port=43123',
    '--no-sandbox',
    '--user-data-dir=/tmp/browserless-data-dirs/browserless-data-dir-506d84a9-a172-45eb-b630-49aa1fabf27e',
    '--load-extension=/app/extensions/clearurls,/app/extensions/privacy_badger,/app/extensions/ublocklite',
    '--disable-extensions-except=/app/extensions/clearurls,/app/extensions/privacy_badger,/app/extensions/ublocklite'
  ],
  executablePath: '/app/playwright-browsers/chromium-1178/chrome-linux/chrome'
} Launching ChromiumCDP Handler
```

---

|测试平台|结果截图|
|-|-|
|`https://adblock-tester.com`|![image](https://github.com/user-attachments/assets/41f2e6aa-a57d-4009-b932-3ff28042d44d)|
|`https://bot.sannysoft.com`|![image](https://github.com/user-attachments/assets/8748a6f2-2699-4476-932f-c836231f3c52)|