### PR TITLE
Migrate to Ghostery adbock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@types/http-proxy": "^1.17.17",
         "@types/micromatch": "^4.0.10",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.8.0",
+        "@types/node": "^25.9.1",
         "@types/sinon": "^21.0.1",
         "@typescript-eslint/eslint-plugin": "^8.59.3",
         "@typescript-eslint/parser": "^8.59.3",
@@ -1857,9 +1857,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
-      "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "playwright-1.58": "npm:playwright-core@1.58.2",
         "playwright-1.59": "npm:playwright-core@1.59.1",
         "playwright-core": "1.60.0",
-        "puppeteer-core": "25.0.3",
+        "puppeteer-core": "25.0.4",
         "puppeteer-extra": "^3.3.6",
         "puppeteer-extra-plugin-stealth": "^2.11.2",
         "queue": "^7.0.0",
@@ -5207,9 +5207,9 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "25.0.3",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.0.3.tgz",
-      "integrity": "sha512-mNT7RWTAzgo9Q+TD8s1XzIOd6/7ZkbF40A0yNYanZOZZ7zSrFN1Am+EtL0nAMU5QWSSv6Dgi+3unRk0saeGcOg==",
+      "version": "25.0.4",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.0.4.tgz",
+      "integrity": "sha512-K1LQKDP6w1rIr1jUyN9obH16TO/DCy86k3q+FBd2prGY+TStxhFySxmaZZuRF+0D3BJXjwCYFke7tMHCH4olTA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "playwright-1.58": "npm:playwright-core@1.58.2",
     "playwright-1.59": "npm:playwright-core@1.59.1",
     "playwright-core": "1.60.0",
-    "puppeteer-core": "25.0.3",
+    "puppeteer-core": "25.0.4",
     "puppeteer-extra": "^3.3.6",
     "puppeteer-extra-plugin-stealth": "^2.11.2",
     "queue": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@types/http-proxy": "^1.17.17",
     "@types/micromatch": "^4.0.10",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.8.0",
+    "@types/node": "^25.9.1",
     "@types/sinon": "^21.0.1",
     "@typescript-eslint/eslint-plugin": "^8.59.3",
     "@typescript-eslint/parser": "^8.59.3",

--- a/src/browsers/browsers.cdp.ts
+++ b/src/browsers/browsers.cdp.ts
@@ -9,11 +9,15 @@ import {
   edgeExecutablePath,
   noop,
   once,
+  // 引入 Privacy Badger 位置
+  privacyBadgerPath,
   ublockLitePath,
 } from '@browserless.io/browserless';
 import puppeteer, { Browser, Page, Target } from 'puppeteer-core';
 import { Duplex } from 'stream';
 import { EventEmitter } from 'events';
+// 引入 adblocker 插件（使用 Ghostery 的实现）
+import { PuppeteerBlocker } from '@ghostery/adblocker-puppeteer';
 import StealthPlugin from 'puppeteer-extra-plugin-stealth';
 import getPort from 'get-port';
 import httpProxy from 'http-proxy';
@@ -35,6 +39,8 @@ export class ChromiumCDP extends EventEmitter {
   protected proxy = httpProxy.createProxyServer();
   protected executablePath = playwright.chromium.executablePath();
   protected keepUntilMS = 0;
+  // Ghostery blocker 实例（或正在创建的 Promise）
+  protected blocker: Promise<PuppeteerBlocker> | null = null;
 
   constructor({
     blockAds,
@@ -53,6 +59,22 @@ export class ChromiumCDP extends EventEmitter {
     this.config = config;
     this.blockAds = blockAds;
     this.logger = logger;
+
+    // stealth 模式下，创建 Ghostery PuppeteerBlocker（屏蔽广告与追踪）
+    if (blockAds) {
+      // 使用预置的 ads+tracking 规则
+      // `fromPrebuiltAdsAndTracking` 需要一个 fetch 实现；Node 18+ 有全局 fetch
+      try {
+        this.blocker = (PuppeteerBlocker as any).fromPrebuiltAdsAndTracking(
+          // @ts-ignore - global fetch
+          fetch,
+        );
+      } catch (e) {
+        // 保持不抛出，以免阻止启动；记录错误并继续
+        this.logger.warn(`Failed to initialize PuppeteerBlocker: ${e}`);
+        this.blocker = null;
+      }
+    }
 
     this.logger.info(`Starting new ${this.constructor.name} instance`);
   }
@@ -135,6 +157,19 @@ export class ChromiumCDP extends EventEmitter {
           }
         });
 
+        // 如果启用了 adblock，向页面注入 Ghostery 屏蔽器
+        if (this.blocker) {
+          try {
+            const blockerInstance: any = await this.blocker;
+            // enableBlockingInPage 会注入内容脚本以拦截请求
+            await blockerInstance.enableBlockingInPage(page);
+          } catch (err) {
+            this.logger.warn(
+              `Failed to enable PuppeteerBlocker on page: ${err}`,
+            );
+          }
+        }
+
         this.emit('newPage', page);
       }
     }
@@ -197,6 +232,8 @@ export class ChromiumCDP extends EventEmitter {
     );
 
     const extensions = [
+      // 引入 Privacy Badger 插件
+      this.blockAds ? privacyBadgerPath : null,
       this.blockAds ? ublockLitePath : null,
       extensionLaunchArgs ? extensionLaunchArgs.split('=')[1] : null,
     ].filter((_) => !!_);
@@ -221,6 +258,29 @@ export class ChromiumCDP extends EventEmitter {
       }
     }
 
+    const patchOptions = [
+      // 浏览器参数
+      '--disable-crashpad',
+      '--disable-crashpad-for-testing',
+      '--disable-crashpad-forwarding',
+      '--disable-in-process-stack-traces',
+      '--no-default-browser-check',
+
+      // 反检测增强
+      '--disable-blink-features=AutomationControlled',
+      '--disable-features=WebRTC',
+      '--exclude-switches=enable-automation',
+      '--no-pings',
+
+      // 性能优化
+      '--aggressive-cache-discard',
+
+      // 容器环境
+      '--disable-setuid-sandbox',
+      '--no-zygote',
+      '--single-process',
+    ];
+
     const finalOptions = {
       ...options,
       args: [
@@ -229,6 +289,8 @@ export class ChromiumCDP extends EventEmitter {
         // Playwright 1.57+ uses Chrome For Test, which has stricter security than Chromium.
         // This is needed to allow WebSocket connections to localhost.
         `--disable-features=LocalNetworkAccessChecks`,
+        // 注入补充 Patch 参数
+        ...patchOptions,
         ...(options.args || []),
         this.userDataDir ? `--user-data-dir=${this.userDataDir}` : '',
       ].filter((_) => !!_),

--- a/src/browsers/browsers.playwright.ts
+++ b/src/browsers/browsers.playwright.ts
@@ -71,10 +71,35 @@ class BasePlaywright extends EventEmitter {
       args.push('--headless=new');
     }
 
+    const patchOptions = [
+      // 浏览器参数
+      '--disable-crashpad',
+      '--disable-crashpad-for-testing',
+      '--disable-crashpad-forwarding',
+      '--disable-in-process-stack-traces',
+      '--no-default-browser-check',
+
+      // 反检测增强
+      '--disable-blink-features=AutomationControlled',
+      '--disable-features=WebRTC',
+      '--exclude-switches=enable-automation',
+      '--no-pings',
+
+      // 性能优化
+      '--aggressive-cache-discard',
+
+      // 容器环境
+      '--disable-setuid-sandbox',
+      '--no-zygote',
+      '--single-process',
+    ];
+
     return {
       ...opts,
       args: [
         ...args,
+        // 注入补充 Patch 参数
+        ...patchOptions,
         // Playwright 1.57+ uses Chrome For Test, which has stricter security than Chromium.
         // This is needed to allow WebSocket connections to localhost.
         `--disable-features=LocalNetworkAccessChecks`,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -939,6 +939,13 @@ export const getCDPClient = (page: Page): CDPSession => {
   return typeof c === 'function' ? c.call(page) : c;
 };
 
+export const privacyBadgerPath = path.join(
+  __dirname,
+  '..',
+  'extensions',
+  'privacy_badger',
+);
+
 export const ublockLitePath = path.join(
   __dirname,
   '..',


### PR DESCRIPTION
## Summary by Sourcery

在 Chromium CDP 和 Playwright 启动流程中集成基于 Ghostery 的广告和追踪器拦截功能，同时统一新增的 Chromium 启动参数，以提升隐蔽性、性能以及在容器环境中的兼容性。

新功能：
- 在启用广告拦截时，添加 Ghostery PuppeteerBlocker 的初始化逻辑以及按页面的拦截功能。
- 在现有 Chromium 系浏览器的 uBlock Lite 集成基础上，新增对 Privacy Badger 扩展的支持。

改进：
- 在 CDP 和 Playwright 两条路径中引入共享的 Chromium 启动标志集，以提升隐蔽性、性能以及容器环境的稳定性。
- 暴露一个可复用的文件系统路径辅助方法，用于 Privacy Badger 扩展。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate Ghostery-based ad and tracker blocking into Chromium CDP and Playwright launches while standardizing additional Chromium launch arguments for stealth, performance, and container compatibility.

New Features:
- Add Ghostery PuppeteerBlocker initialization and per-page blocking when ad blocking is enabled.
- Add Privacy Badger extension support alongside existing uBlock Lite integration for Chromium-based browsers.

Enhancements:
- Introduce a shared set of Chromium launch flags in both CDP and Playwright paths to improve stealth, performance, and container environment stability.
- Expose a reusable filesystem path helper for the Privacy Badger extension.

</details>