### PR TITLE
 feat: enhance adblock function, migrate to Ghostery adbock

### DIFF
--- a/src/browsers/browsers.cdp.ts
+++ b/src/browsers/browsers.cdp.ts
@@ -9,11 +9,15 @@ import {
   edgeExecutablePath,
   noop,
   once,
+  // 引入 Privacy Badger 位置
+  privacyBadgerPath,
   ublockLitePath,
 } from '@browserless.io/browserless';
 import puppeteer, { Browser, Page, Target } from 'puppeteer-core';
 import { Duplex } from 'stream';
 import { EventEmitter } from 'events';
+// 引入 adblocker 插件（使用 Ghostery 的实现）
+import { PuppeteerBlocker } from '@ghostery/adblocker-puppeteer';
 import StealthPlugin from 'puppeteer-extra-plugin-stealth';
 import getPort from 'get-port';
 import httpProxy from 'http-proxy';
@@ -35,6 +39,8 @@ export class ChromiumCDP extends EventEmitter {
   protected proxy = httpProxy.createProxyServer();
   protected executablePath = playwright.chromium.executablePath();
   protected keepUntilMS = 0;
+  // Ghostery blocker 实例（或正在创建的 Promise）
+  protected blocker: Promise<PuppeteerBlocker | null> | null = null;
 
   constructor({
     blockAds,
@@ -53,6 +59,16 @@ export class ChromiumCDP extends EventEmitter {
     this.config = config;
     this.blockAds = blockAds;
     this.logger = logger;
+
+    // stealth 模式下，创建 Ghostery PuppeteerBlocker（屏蔽广告与追踪）
+    if (blockAds) {
+      this.blocker = (PuppeteerBlocker as any)
+        .fromPrebuiltAdsAndTracking(fetch as any)
+        .catch((e: unknown) => {
+          this.logger.warn(`Failed to initialize PuppeteerBlocker: ${e}`);
+          return null; // 或视需求选择重新抛出
+        });
+    }
 
     this.logger.info(`Starting new ${this.constructor.name} instance`);
   }
@@ -135,6 +151,19 @@ export class ChromiumCDP extends EventEmitter {
           }
         });
 
+        // 如果启用了 adblock，向页面注入 Ghostery 屏蔽器
+        if (this.blocker) {
+          try {
+            const blockerInstance: any = await this.blocker;
+            // enableBlockingInPage 会注入内容脚本以拦截请求
+            await blockerInstance.enableBlockingInPage(page);
+          } catch (err) {
+            this.logger.warn(
+              `Failed to enable PuppeteerBlocker on page: ${err}`,
+            );
+          }
+        }
+
         this.emit('newPage', page);
       }
     }
@@ -197,6 +226,8 @@ export class ChromiumCDP extends EventEmitter {
     );
 
     const extensions = [
+      // 引入 Privacy Badger 插件
+      this.blockAds ? privacyBadgerPath : null,
       this.blockAds ? ublockLitePath : null,
       extensionLaunchArgs ? extensionLaunchArgs.split('=')[1] : null,
     ].filter((_) => !!_);
@@ -221,6 +252,32 @@ export class ChromiumCDP extends EventEmitter {
       }
     }
 
+    const patchOptions = [
+      // 浏览器参数
+      '--disable-crashpad',
+      '--disable-crashpad-for-testing',
+      '--disable-crashpad-forwarding',
+      '--disable-in-process-stack-traces',
+      '--no-default-browser-check',
+
+      // 反检测增强
+      '--disable-blink-features=AutomationControlled',
+      '--disable-features=LocalNetworkAccessChecks,WebRtcHideLocalIpsWithMdns',
+      '--enforce-webrtc-ip-permission-check',
+      '--exclude-switches=enable-automation',
+      '--force-webrtc-ip-handling-policy',
+      '--no-pings',
+      '--webrtc-ip-handling-policy=disable_non_proxied_udp',
+
+      // 性能优化
+      '--aggressive-cache-discard',
+
+      // 容器环境
+      '--disable-setuid-sandbox',
+      '--no-zygote',
+      '--single-process',
+    ];
+
     const finalOptions = {
       ...options,
       args: [
@@ -229,6 +286,8 @@ export class ChromiumCDP extends EventEmitter {
         // Playwright 1.57+ uses Chrome For Test, which has stricter security than Chromium.
         // This is needed to allow WebSocket connections to localhost.
         `--disable-features=LocalNetworkAccessChecks`,
+        // 注入补充 Patch 参数
+        ...patchOptions,
         ...(options.args || []),
         this.userDataDir ? `--user-data-dir=${this.userDataDir}` : '',
       ].filter((_) => !!_),

--- a/src/browsers/browsers.playwright.ts
+++ b/src/browsers/browsers.playwright.ts
@@ -71,10 +71,38 @@ class BasePlaywright extends EventEmitter {
       args.push('--headless=new');
     }
 
+    const patchOptions = [
+      // 浏览器参数
+      '--disable-crashpad',
+      '--disable-crashpad-for-testing',
+      '--disable-crashpad-forwarding',
+      '--disable-in-process-stack-traces',
+      '--no-default-browser-check',
+
+      // 反检测增强
+      '--disable-blink-features=AutomationControlled',
+      '--disable-features=LocalNetworkAccessChecks,WebRtcHideLocalIpsWithMdns',
+      '--enforce-webrtc-ip-permission-check',
+      '--exclude-switches=enable-automation',
+      '--force-webrtc-ip-handling-policy',
+      '--no-pings',
+      '--webrtc-ip-handling-policy=disable_non_proxied_udp',
+
+      // 性能优化
+      '--aggressive-cache-discard',
+
+      // 容器环境
+      '--disable-setuid-sandbox',
+      '--no-zygote',
+      '--single-process',
+    ];
+
     return {
       ...opts,
       args: [
         ...args,
+        // 注入补充 Patch 参数
+        ...patchOptions,
         // Playwright 1.57+ uses Chrome For Test, which has stricter security than Chromium.
         // This is needed to allow WebSocket connections to localhost.
         `--disable-features=LocalNetworkAccessChecks`,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -939,6 +939,13 @@ export const getCDPClient = (page: Page): CDPSession => {
   return typeof c === 'function' ? c.call(page) : c;
 };
 
+export const privacyBadgerPath = path.join(
+  __dirname,
+  '..',
+  'extensions',
+  'privacy_badger',
+);
+
 export const ublockLitePath = path.join(
   __dirname,
   '..',


### PR DESCRIPTION
## Summary by Sourcery

将增强的广告拦截和反检测行为集成到 Chromium/Playwright 浏览器中，并更新相关依赖。

新功能：
- 当启用广告拦截时，添加基于 Ghostery 的 PuppeteerBlocker 初始化，以及按页面进行广告/跟踪器拦截。
- 当启用广告拦截时，与 uBlock Lite 一同加载 Privacy Badger 扩展。

增强：
- 在 CDP 和 Playwright 流程中应用一组共享的 Chromium 启动补丁选项，以提升隐身能力、性能和容器兼容性。

构建：
- 将 puppeteer-core 和 @types/node 升级到更新的补丁版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate enhanced ad blocking and anti-detection behavior into Chromium/Playwright browsers while updating related dependencies.

New Features:
- Add Ghostery-based PuppeteerBlocker initialization and per-page ad/tracker blocking when ad blocking is enabled.
- Load the Privacy Badger extension alongside uBlock Lite when ad blocking is enabled.

Enhancements:
- Apply a shared set of Chromium launch patch options in both CDP and Playwright flows to improve stealth, performance, and container compatibility.

Build:
- Bump puppeteer-core and @types/node to newer patch versions.

</details>