### PR TITLE
feat: harden Chromium args, enable Privacy Badger & adblocker

### DIFF
--- a/src/browsers/browsers.cdp.ts
+++ b/src/browsers/browsers.cdp.ts
@@ -10,11 +10,18 @@ import {
   findBlockedNavigationUrl,
   noop,
   once,
+  // <PATCH>Privacy Badger</PATCH>
+  privacyBadgerPath,
+  // <PATCH>Privacy Badger</PATCH>
   ublockLitePath,
 } from '@browserless.io/browserless';
 import puppeteer, { Browser, Page, Target } from 'puppeteer-core';
 import { Duplex } from 'stream';
 import { EventEmitter } from 'events';
+// <PATCH>@zorilla/puppeteer-extra-plugin-adblocker</PATCH>
+import { DEFAULT_INTERCEPT_RESOLUTION_PRIORITY } from 'puppeteer'
+import AdblockerPlugin from '@zorilla/puppeteer-extra-plugin-adblocker';
+// <PATCH>@zorilla/puppeteer-extra-plugin-adblocker</PATCH>
 import StealthPlugin from '@zorilla/puppeteer-extra-plugin-stealth';
 import { addExtra } from '@zorilla/puppeteer-extra';
 import getPort from 'get-port';
@@ -212,6 +219,18 @@ export class ChromiumCDP extends EventEmitter {
     this.port = await getPort();
     this.logger.debug(`${this.constructor.name} got open port ${this.port}`);
 
+    // <PATCH>@zorilla/puppeteer-extra-plugin-adblocker</PATCH>
+    if (this.blockAds) {
+      puppeteerStealth.use(
+        AdblockerPlugin({
+          blockTrackersAndAnnoyances: true,
+          interceptResolutionPriority: DEFAULT_INTERCEPT_RESOLUTION_PRIORITY,
+          useCache: true,
+        }) as unknown as Parameters<typeof puppeteerStealth.use>[0],
+      );
+    }
+    // <PATCH>@zorilla/puppeteer-extra-plugin-adblocker</PATCH>
+
     const extensionLaunchArgs = options.args?.find((a) =>
       a.startsWith('--load-extension'),
     );
@@ -224,6 +243,9 @@ export class ChromiumCDP extends EventEmitter {
     );
 
     const extensions = [
+      // <PATCH>@zorilla/puppeteer-extra-plugin-adblocker</PATCH>
+      this.blockAds ? privacyBadgerPath : null,
+      // <PATCH>@zorilla/puppeteer-extra-plugin-adblocker</PATCH>
       this.blockAds ? ublockLitePath : null,
       extensionLaunchArgs ? extensionLaunchArgs.split('=')[1] : null,
     ].filter((_) => !!_);
@@ -248,6 +270,30 @@ export class ChromiumCDP extends EventEmitter {
       }
     }
 
+    // <PATCH>Browser Options</PATCH>
+    const patchOptions = [
+      '--disable-crashpad',
+      '--disable-crashpad-for-testing',
+      '--disable-crashpad-forwarding',
+      '--disable-in-process-stack-traces',
+      '--no-default-browser-check',
+
+      '--disable-blink-features=AutomationControlled',
+      '--disable-features=LocalNetworkAccessChecks,WebRtcHideLocalIpsWithMdns',
+      '--enforce-webrtc-ip-permission-check',
+      '--exclude-switches=enable-automation',
+      '--force-webrtc-ip-handling-policy',
+      '--no-pings',
+      '--webrtc-ip-handling-policy=disable_non_proxied_udp',
+
+      '--aggressive-cache-discard',
+
+      '--disable-setuid-sandbox',
+      '--no-zygote',
+      '--single-process',
+    ];
+    // <PATCH>Browser Options</PATCH>
+
     const finalOptions = {
       ...options,
       args: [
@@ -256,6 +302,9 @@ export class ChromiumCDP extends EventEmitter {
         // Playwright 1.57+ uses Chrome For Test, which has stricter security than Chromium.
         // This is needed to allow WebSocket connections to localhost.
         `--disable-features=LocalNetworkAccessChecks`,
+        // <PATCH>Browser Options</PATCH>
+        ...patchOptions,
+        // <PATCH>Browser Options</PATCH>
         ...(options.args || []),
         this.userDataDir ? `--user-data-dir=${this.userDataDir}` : '',
       ].filter((_) => !!_),

--- a/src/browsers/browsers.playwright.ts
+++ b/src/browsers/browsers.playwright.ts
@@ -127,6 +127,30 @@ class BasePlaywright extends EventEmitter {
       args.push('--headless=new');
     }
 
+    // <PATCH>Browser Options</PATCH>
+    const patchOptions = [
+      '--disable-crashpad',
+      '--disable-crashpad-for-testing',
+      '--disable-crashpad-forwarding',
+      '--disable-in-process-stack-traces',
+      '--no-default-browser-check',
+
+      '--disable-blink-features=AutomationControlled',
+      '--disable-features=LocalNetworkAccessChecks,WebRtcHideLocalIpsWithMdns',
+      '--enforce-webrtc-ip-permission-check',
+      '--exclude-switches=enable-automation',
+      '--force-webrtc-ip-handling-policy',
+      '--no-pings',
+      '--webrtc-ip-handling-policy=disable_non_proxied_udp',
+
+      '--aggressive-cache-discard',
+
+      '--disable-setuid-sandbox',
+      '--no-zygote',
+      '--single-process',
+    ];
+    // <PATCH>Browser Options</PATCH>
+
     return {
       ...opts,
       args: [
@@ -141,6 +165,9 @@ class BasePlaywright extends EventEmitter {
           this.config.getChromiumDisabledFeatures(pwVersion),
           this.config.getBrowserlessChromiumDisabledFeatures(),
         ),
+        // <PATCH>Browser Options</PATCH>
+        ...patchOptions,
+        // <PATCH>Browser Options</PATCH>
         this.userDataDir ? `--user-data-dir=${this.userDataDir}` : '',
       ],
       executablePath: this.executablePath(),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1023,6 +1023,15 @@ export const getCDPClient = (page: Page): CDPSession => {
   return typeof c === 'function' ? c.call(page) : c;
 };
 
+// <PATCH>Privacy Badger</PATCH>
+export const privacyBadgerPath = path.join(
+  __dirname,
+  '..',
+  'extensions',
+  'privacy_badger',
+);
+// <PATCH>Privacy Badger</PATCH>
+
 export const ublockLitePath = path.join(
   __dirname,
   '..',


### PR DESCRIPTION
## Summary by Sourcery

将增强的广告拦截和隐私功能集成到 Chromium CDP 和 Playwright 浏览器启动流程中。

新特性：
- 当启用广告拦截配置时，在 Puppeteer 中通过 `@zorilla/puppeteer-extra-plugin-adblocker` 启用广告拦截。
- 在启用广告拦截时，加载 Privacy Badger 扩展，与 uBlock Lite 一同使用。
- 为 Puppeteer 和 Playwright 引入一组共享的强化版 Chromium 启动参数，以提升隐私保护、降低自动化检测风险，并调整运行时行为。

改进：
- 添加可复用的 `privacyBadgerPath` 工具函数，用于解析 Privacy Badger 扩展的位置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate enhanced adblocking and privacy features into Chromium CDP and Playwright browser launches.

New Features:
- Enable adblocking in Puppeteer via the @zorilla/puppeteer-extra-plugin-adblocker when ad blocking is configured.
- Load the Privacy Badger extension alongside uBlock Lite when ad blocking is enabled.
- Introduce a shared set of hardened Chromium launch flags for both Puppeteer and Playwright to improve privacy, reduce automation detection, and tweak runtime behavior.

Enhancements:
- Add a reusable privacyBadgerPath utility for resolving the Privacy Badger extension location.

</details>